### PR TITLE
Fix #14 and fix #21 – Add branch coverage for function 8 and create a shared method for writing to .csv files

### DIFF
--- a/src/de/gurkenlabs/litiengine/environment/tilemap/xml/Layer.java
+++ b/src/de/gurkenlabs/litiengine/environment/tilemap/xml/Layer.java
@@ -62,7 +62,7 @@ public abstract class Layer extends CustomPropertyProvider implements ILayer, Se
    * Copy Constructor for copying instances of Layers.
    *
    * @param layerToBeCopied
-   *          the layer we want to copy
+   *                          the layer we want to copy
    */
   public Layer(Layer layerToBeCopied) {
     super(layerToBeCopied);
@@ -233,8 +233,16 @@ public abstract class Layer extends CustomPropertyProvider implements ILayer, Se
 
   @SuppressWarnings("unused")
   private void afterUnmarshal(Unmarshaller u, Object parent) {
+    int numberOfBranches = 17;
+    int branches[] = new int[numberOfBranches];
+
+    branches[0] = 1;
+
     if (parent instanceof Map) {
       this.parentMap = (Map) parent;
+      branches[1] = 1;
+    } else {
+      branches[2] = 1;
     }
 
     int order = this.getIntValue(LayerProperty.LAYER_ORDER, -1);
@@ -243,30 +251,52 @@ public abstract class Layer extends CustomPropertyProvider implements ILayer, Se
       layerCnt += this.parentMap.getRawMapObjectLayers().size();
       layerCnt += this.parentMap.getRawTileLayers().size();
       this.setOrder(layerCnt);
+
+      branches[3] = 1;
+    } else {
+      branches[4] = 1;
     }
 
     if (this.offsetx != null && this.offsetx.intValue() == 0) {
       this.offsetx = null;
+      branches[5] = 1;
+    } else {
+      branches[6] = 1;
     }
 
     if (this.offsety != null && this.offsety.intValue() == 0) {
       this.offsety = null;
+      branches[7] = 1;
+    } else {
+      branches[8] = 1;
     }
 
     if (this.width != null && this.width.intValue() == 0) {
       this.width = null;
+      branches[9] = 1;
+    } else {
+      branches[10] = 1;
     }
 
     if (this.height != null && this.height.intValue() == 0) {
       this.height = null;
+      branches[11] = 1;
+    } else {
+      branches[12] = 1;
     }
 
     if (this.opacity != null && this.opacity.floatValue() == 1.0f) {
       this.opacity = null;
+      branches[13] = 1;
+    } else {
+      branches[14] = 1;
     }
 
     if (this.visible != null && this.visible.intValue() == 1) {
       this.visible = null;
+      branches[15] = 1;
+    } else {
+      branches[16] = 1;
     }
   }
 }

--- a/src/de/gurkenlabs/litiengine/environment/tilemap/xml/Layer.java
+++ b/src/de/gurkenlabs/litiengine/environment/tilemap/xml/Layer.java
@@ -13,6 +13,8 @@ import de.gurkenlabs.litiengine.environment.tilemap.IMap;
 import de.gurkenlabs.litiengine.environment.tilemap.LayerProperty;
 import de.gurkenlabs.litiengine.graphics.RenderType;
 
+import de.gurkenlabs.litiengine.util.io.CSV;
+
 /**
  * The Class Layer.
  */
@@ -297,6 +299,12 @@ public abstract class Layer extends CustomPropertyProvider implements ILayer, Se
       branches[15] = 1;
     } else {
       branches[16] = 1;
+    }
+
+    try {
+      CSV.write(branches, 8);
+    } catch (Exception e) {
+      System.err.println("Error: " + e);
     }
   }
 }

--- a/src/de/gurkenlabs/litiengine/util/io/CSV.java
+++ b/src/de/gurkenlabs/litiengine/util/io/CSV.java
@@ -6,7 +6,7 @@ public class CSV {
 
   public static void write(int branches[], int functionNumber) throws Exception {
     try {
-      FileWriter fw = new FileWriter("branchtest/test_" + functionNumber + ".csv", true);
+      FileWriter fw = new FileWriter("branchtest/test_" + (functionNumber < 10 ? "0" + functionNumber : functionNumber) + ".csv", true);
       BufferedWriter bw = new BufferedWriter(fw);
       PrintWriter pw = new PrintWriter(bw);
       pw.print(branches[0]);

--- a/src/de/gurkenlabs/litiengine/util/io/CSV.java
+++ b/src/de/gurkenlabs/litiengine/util/io/CSV.java
@@ -1,0 +1,25 @@
+package de.gurkenlabs.litiengine.util.io;
+
+import java.io.*;
+
+public class CSV {
+
+  public static void write(int branches[], int functionNumber) throws Exception {
+    try {
+      FileWriter fw = new FileWriter("branchtest/test_" + functionNumber + ".csv", true);
+      BufferedWriter bw = new BufferedWriter(fw);
+      PrintWriter pw = new PrintWriter(bw);
+      pw.print(branches[0]);
+      for (int i = 1; i < branches.length; i++) {
+        pw.print(",");
+        pw.print(branches[i]);
+      }
+      pw.println();
+      pw.flush();
+      bw.close();
+      fw.close();
+    } catch (Exception e) {
+      System.exit(1);
+    }
+  }
+}


### PR DESCRIPTION
This adds branch coverage for function number eight and also implements a class for writing to our `.csv` files. To use the new class you import it like this

```
import de.gurkenlabs.litiengine.util.io.CSV;
```

and use it like this

```
try {
  CSV.write(branches, 8);
} catch (Exception e) {
  System.err.println("Error: " + e);
}
```

where `branches` is your int array of branches and `8` (an example) is your function number.

