### PR TITLE
Fix #105 Refactor: Extract methods from function canCast()

### DIFF
--- a/src/de/gurkenlabs/litiengine/abilities/Ability.java
+++ b/src/de/gurkenlabs/litiengine/abilities/Ability.java
@@ -73,7 +73,15 @@ public abstract class Ability implements IRenderable {
   }
 
   public boolean canCast() {
-    return !this.getExecutor().isDead() && (this.getCurrentExecution() == null || this.getCurrentExecution().getExecutionTicks() == 0 || Game.loop().getDeltaTime(this.getCurrentExecution().getExecutionTicks()) >= this.getAttributes().getCooldown().getCurrentValue());
+    return !this.getExecutor().isDead() && !this.isCurrentlyExecuting() && !this.isColdownLeft();
+  }
+
+  private boolean isCurrentlyExecuting() {
+    return this.getCurrentExecution() != null && this.getCurrentExecution().getExecutionTicks() != 0;
+  }
+
+  private boolean isColdownLeft() {
+    return Game.loop().getDeltaTime(this.getCurrentExecution().getExecutionTicks()) < this.getAttributes().getCooldown().getCurrentValue();
   }
 
   /**


### PR DESCRIPTION
I refactored the method canCast() of Ability. I extracted two methods from it that makes the function a bit more descriptive and easy to understand.